### PR TITLE
Added support for running OVMF to directly boot ACRN SOS.

### DIFF
--- a/OvmfPkg/Include/IndustryStandard/AcrnPlatform.h
+++ b/OvmfPkg/Include/IndustryStandard/AcrnPlatform.h
@@ -13,14 +13,28 @@
 #ifndef __ACRN_PLATFORM_H__
 #define __ACRN_PLATFORM_H__
 
+#include <IndustryStandard/E820.h>
 //
 // Host Bridge Device ID (DID) value for ACRN
 //
-#define ACRN_HOSTBRIDGE_DEVICE_ID 0x1275
-
+#ifdef OVMF_AS_ACRN_SOS
+#define ACRN_HOSTBRIDGE_DEVICE_ID 0x5af0U
+#define ACRN_E820_PHYSICAL_ADDRESS 0x00001000U 
+#else
+#define ACRN_HOSTBRIDGE_DEVICE_ID 0x1275U
+#define ACRN_E820_PHYSICAL_ADDRESS  0x000EF000U
+#endif
 //
 // Values we program into the PM base address registers
 //
 #define ACRN_PMBASE_VALUE 0x400
+
+#pragma pack(1)
+  typedef struct {
+    CHAR8             Signature[4];
+    UINT32            E820EntriesCount;
+    EFI_E820_ENTRY64  E820Map[];
+  } ACRN_E820_INFO;
+#pragma pack()
 
 #endif

--- a/OvmfPkg/OvmfPkg.dec
+++ b/OvmfPkg/OvmfPkg.dec
@@ -97,7 +97,7 @@
 
   ## This flag is used to control the destination port for PlatformDebugLibIoPort
   #gUefiOvmfPkgTokenSpaceGuid.PcdDebugIoPort|0x402|UINT16|4
-  gUefiOvmfPkgTokenSpaceGuid.PcdDebugIoPort|0x2F8|UINT16|4
+  gUefiOvmfPkgTokenSpaceGuid.PcdDebugIoPort|0x3F8|UINT16|4
 
   ## When VirtioScsiDxe is instantiated for a HBA, the numbers of targets and
   #  LUNs are retrieved from the host during virtio-scsi setup.

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -73,6 +73,9 @@
   GCC:*_*_X64_GENFW_FLAGS   = --keepexceptiontable
   INTEL:*_*_X64_GENFW_FLAGS = --keepexceptiontable
 !endif
+!ifdef $(OVMF_AS_ACRN_SOS)
+  GCC:*_*_*_CC_FLAGS                   = -DOVMF_AS_ACRN_SOS
+!endif
 
   #
   # Disable deprecated APIs.

--- a/OvmfPkg/PlatformPei/Acrn.c
+++ b/OvmfPkg/PlatformPei/Acrn.c
@@ -22,16 +22,7 @@
 #include <Library/MtrrLib.h>
 
 #include "Platform.h"
-
-#define ACRN_E820_PHYSICAL_ADDRESS          0x000EF000
-
-#pragma pack(1)
-  typedef struct {
-    CHAR8             Signature[4];
-    UINT32            E820EntriesCount;
-    EFI_E820_ENTRY64  E820Map[];
-  } ACRN_E820_INFO;
-#pragma pack()
+#include <IndustryStandard/AcrnPlatform.h>
 
 
 STATIC

--- a/OvmfPkg/PlatformPei/MemDetect.c
+++ b/OvmfPkg/PlatformPei/MemDetect.c
@@ -22,7 +22,7 @@ Module Name:
 #include <IndustryStandard/E820.h>
 #include <IndustryStandard/Q35MchIch9.h>
 #include <PiPei.h>
-
+ 
 //
 // The Library classes this module consumes
 //
@@ -40,6 +40,7 @@ Module Name:
 
 #include "Platform.h"
 #include "Cmos.h"
+#include <IndustryStandard/AcrnPlatform.h>
 
 UINT8 mPhysMemAddressWidth;
 

--- a/OvmfPkg/PlatformPei/Platform.c
+++ b/OvmfPkg/PlatformPei/Platform.c
@@ -206,7 +206,8 @@ MemMapInitialization (
       //
       PciExBarBase = FixedPcdGet64 (PcdPciExpressBaseAddress);
       ASSERT (PciExBarBase <= MAX_UINT32 - SIZE_256MB);
-      PciBase = BASE_2GB;
+      //set PciBase to the nearest upper-256MB Segment
+      PciBase = ((TopOfLowRam - 1) | 0x0FFFFFFFU) + 1;
       ASSERT (TopOfLowRam <= PciBase);
       ASSERT (PciBase < PciExBarBase);
       PciSize = PciExBarBase - PciBase;


### PR DESCRIPTION
1. Added an option "OVMF_AS_ACRN_SOS" to distinguish from the default
target (as UOS firmware). The E820 pointer and Hostbridge_id is
determined by this option since they are different btw UOS and SOS.

2. Modified the approach to search the RSDP for ACRN/Xen. Besides
default range (0xEA000~0xFFFFF), OVMF will now search RSDP in ACPI data
segment (marked as 3 in E820 table), this will help OVMF to find RSDP on
some newer BIOS that may place RDSP elsewhere.

3. Re-set PciBase to the nearest upper 256MB segment of TopOfLowRam

4. Added Nvme Driver back.

The changes are verified on Kbl-Nuc-i7 and Whl-ipc-i5.