### PR TITLE
Add MemoryFence to AcrnEmuVariableFvbRuntimeDxe

### DIFF
--- a/OvmfPkg/AcrnEmuVariableFvbRuntimeDxe/Fvb.c
+++ b/OvmfPkg/AcrnEmuVariableFvbRuntimeDxe/Fvb.c
@@ -365,7 +365,9 @@ FvbProtocolEraseBlocks (
     ErasePtr += (UINTN)StartingLba * FvbDevice->BlockSize;
     EraseSize = NumOfLba * FvbDevice->BlockSize;
 
+    MemoryFence ();
     SetMem (ErasePtr, EraseSize, ERASED_UINT8);
+    MemoryFence ();
   } while (1);
   VA_END (Args);
 
@@ -844,7 +846,9 @@ FvbInitialize (
   // Initialize the main FV header and variable store header
   //
   if (Initialize) {
+    MemoryFence ();
     SetMem (Ptr, EMU_FVB_SIZE, ERASED_UINT8);
+    MemoryFence ();
     InitializeFvAndVariableStoreHeaders (Ptr);
   }
 


### PR DESCRIPTION
To prevent the compiler optimization of SetMem which is to scrub a
memory region which contains the sensitive data, using memory
barrier for SetMem when an optimization flag is enabled.

This is to comply with an SDL rule.

Signed-off-by: Yang, Yu-chu <yu-chu.yang@intel.com>