### PR TITLE
OvmfPkg/SataControllerDxe: Calculate ChannelCount based on PI value

### DIFF
--- a/OvmfPkg/SataControllerDxe/SataController.h
+++ b/OvmfPkg/SataControllerDxe/SataController.h
@@ -39,7 +39,8 @@ extern EFI_COMPONENT_NAME2_PROTOCOL gSataControllerComponentName2;
 #define AHCI_BAR_INDEX 0x05
 #define R_AHCI_CAP 0x0
 #define   B_AHCI_CAP_NPS (BIT4 | BIT3 | BIT2 | BIT1 | BIT0) // Number of Ports
-#define   B_AHCI_CAP_SPM BIT17 // Supports Port Multiplier
+#define   B_AHCI_CAP_SPM BIT17                              // Supports Port Multiplier
+#define R_AHCI_PI  0xC
 
 ///
 /// AHCI each channel can have up to 1 device


### PR DESCRIPTION
Port the following fix from MdeModulePkg/SataControllerDxe, as we have
observed platforms with CAP(NP) = 0 and port 1 implemented:

commit aa4240edff41034d709938a15b42cf4fd3214386
Author: Star Zeng <star.zeng@intel.com>
Date:   Wed Jun 27 14:10:45 2018 +0800

    MdeModulePkg SataControllerDxe: Calculate ChannelCount based on PI value

    Current code calculates ChannelCount based on CAP(NP) value.
    It only works when the ports implemented number are <= CAP(NP),
    for example, platform has CAP(NP) = 5 (means 6 ports) and ports
    implemented are 0, 1, 2, 3, 4 and 5.

    But we have some platform that has CAP(NP) = 1 (means 2 ports) and
    ports implemented are 1 and 2, and has no port 0 implemented, then
    current code does not work.

    This patch updates the code to calculate ChannelCount based on PI value.

    Cc: Amy Chan <amy.chan@intel.com>
    Cc: Hong-chihX Hsueh <hong-chihx.hsueh@intel.com>
    Cc: Jiewen Yao <jiewen.yao@intel.com>
    Cc: Sami Mujawar <sami.mujawar@arm.com>
    Cc: Ruiyu Ni <ruiyu.ni@intel.com>
    Cc: Hao Wu <hao.a.wu@intel.com>
    Contributed-under: TianoCore Contribution Agreement 1.1
    Signed-off-by: Star Zeng <star.zeng@intel.com>
    Reviewed-by: Hao Wu <hao.a.wu@intel.com>
    Tested-by: Hong-chihX Hsueh <hong-chihx.hsueh@intel.com>

M       MdeModulePkg/Bus/Pci/SataControllerDxe/SataController.c
M       MdeModulePkg/Bus/Pci/SataControllerDxe/SataController.h

Reported-by: Conghui Chen <conghui.chen@intel.com>
Tested-by: Li, RuiX <ruix.li@intel.com>
Tested-by: Zheng, Shuang <shuang.zheng@intel.com>
Signed-off-by: Peter Fang <peter.fang@intel.com>