### PR TITLE
TSC delay timer library and lapic timer driver

### DIFF
--- a/OvmfPkg/AcrnLapicTimerDxe/AcrnLapicTimer.c
+++ b/OvmfPkg/AcrnLapicTimerDxe/AcrnLapicTimer.c
@@ -1,0 +1,653 @@
+/** @file
+  Timer Architectural Protocol module using Local Advanced Programmable Interrupt
+  Controller (LAPIC) Timer.
+
+  Copyright (c) 2011 - 2020, Intel Corporation. All rights reserved.<BR>
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+
+#include <PiDxe.h>
+
+#include <Protocol/Cpu.h>
+#include <Protocol/Timer.h>
+
+#include <Library/IoLib.h>
+#include <Library/PcdLib.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/LocalApicLib.h>
+
+#include <Register/LocalApic.h>
+#include <Register/Cpuid.h>
+#include <Register/ArchitecturalMsr.h>
+
+///
+/// Timer Architectural Protocol function prototypes.
+///
+
+/**
+  This function registers the handler NotifyFunction so it is called every time
+  the timer interrupt fires.  It also passes the amount of time since the last
+  handler call to the NotifyFunction.  If NotifyFunction is NULL, then the
+  handler is unregistered.  If the handler is registered, then EFI_SUCCESS is
+  returned.  If the CPU does not support registering a timer interrupt handler,
+  then EFI_UNSUPPORTED is returned.  If an attempt is made to register a handler
+  when a handler is already registered, then EFI_ALREADY_STARTED is returned.
+  If an attempt is made to unregister a handler when a handler is not registered,
+  then EFI_INVALID_PARAMETER is returned.  If an error occurs attempting to
+  register the NotifyFunction with the timer interrupt, then EFI_DEVICE_ERROR
+  is returned.
+
+  @param  This            The EFI_TIMER_ARCH_PROTOCOL instance.
+  @param  NotifyFunction  The function to call when a timer interrupt fires.
+                          This function executes at TPL_HIGH_LEVEL.  The DXE
+                          Core will register a handler for the timer interrupt,
+                          so it can know how much time has passed.  This
+                          information is used to signal timer based events.
+                          NULL will unregister the handler.
+
+  @retval  EFI_SUCCESS            The timer handler was registered.
+  @retval  EFI_UNSUPPORTED        The platform does not support timer interrupts.
+  @retval  EFI_ALREADY_STARTED    NotifyFunction is not NULL, and a handler is already
+                                  registered.
+  @retval  EFI_INVALID_PARAMETER  NotifyFunction is NULL, and a handler was not
+                                  previously registered.
+  @retval  EFI_DEVICE_ERROR       The timer handler could not be registered.
+
+**/
+EFI_STATUS
+EFIAPI
+TimerDriverRegisterHandler (
+  IN EFI_TIMER_ARCH_PROTOCOL  *This,
+  IN EFI_TIMER_NOTIFY         NotifyFunction
+  );
+
+/**
+  This function adjusts the period of timer interrupts to the value specified
+  by TimerPeriod.  If the timer period is updated, then the selected timer
+  period is stored in EFI_TIMER.TimerPeriod, and EFI_SUCCESS is returned.  If
+  the timer hardware is not programmable, then EFI_UNSUPPORTED is returned.
+  If an error occurs while attempting to update the timer period, then the
+  timer hardware will be put back in its state prior to this call, and
+  EFI_DEVICE_ERROR is returned.  If TimerPeriod is 0, then the timer interrupt
+  is disabled.  This is not the same as disabling the CPU's interrupts.
+  Instead, it must either turn off the timer hardware, or it must adjust the
+  interrupt controller so that a CPU interrupt is not generated when the timer
+  interrupt fires.
+
+  @param  This         The EFI_TIMER_ARCH_PROTOCOL instance.
+  @param  TimerPeriod  The rate to program the timer interrupt in 100 nS units.
+                       If the timer hardware is not programmable, then
+                       EFI_UNSUPPORTED is returned.  If the timer is programmable,
+                       then the timer period will be rounded up to the nearest
+                       timer period that is supported by the timer hardware.
+                       If TimerPeriod is set to 0, then the timer interrupts
+                       will be disabled.
+
+  @retval  EFI_SUCCESS       The timer period was changed.
+  @retval  EFI_UNSUPPORTED   The platform cannot change the period of the timer interrupt.
+  @retval  EFI_DEVICE_ERROR  The timer period could not be changed due to a device error.
+
+**/
+EFI_STATUS
+EFIAPI
+TimerDriverSetTimerPeriod (
+  IN EFI_TIMER_ARCH_PROTOCOL  *This,
+  IN UINT64                   TimerPeriod
+  );
+
+/**
+  This function retrieves the period of timer interrupts in 100 ns units,
+  returns that value in TimerPeriod, and returns EFI_SUCCESS.  If TimerPeriod
+  is NULL, then EFI_INVALID_PARAMETER is returned.  If a TimerPeriod of 0 is
+  returned, then the timer is currently disabled.
+
+  @param  This         The EFI_TIMER_ARCH_PROTOCOL instance.
+  @param  TimerPeriod  A pointer to the timer period to retrieve in 100 ns units.
+                       If 0 is returned, then the timer is currently disabled.
+
+  @retval  EFI_SUCCESS            The timer period was returned in TimerPeriod.
+  @retval  EFI_INVALID_PARAMETER  TimerPeriod is NULL.
+
+**/
+EFI_STATUS
+EFIAPI
+TimerDriverGetTimerPeriod (
+  IN EFI_TIMER_ARCH_PROTOCOL   *This,
+  OUT UINT64                   *TimerPeriod
+  );
+
+/**
+  This function generates a soft timer interrupt. If the platform does not support soft
+  timer interrupts, then EFI_UNSUPPORTED is returned. Otherwise, EFI_SUCCESS is returned.
+  If a handler has been registered through the EFI_TIMER_ARCH_PROTOCOL.RegisterHandler()
+  service, then a soft timer interrupt will be generated. If the timer interrupt is
+  enabled when this service is called, then the registered handler will be invoked. The
+  registered handler should not be able to distinguish a hardware-generated timer
+  interrupt from a software-generated timer interrupt.
+
+  @param  This  The EFI_TIMER_ARCH_PROTOCOL instance.
+
+  @retval  EFI_SUCCESS       The soft timer interrupt was generated.
+  @retval  EFI_UNSUPPORTED   The platform does not support the generation of soft
+                             timer interrupts.
+
+**/
+EFI_STATUS
+EFIAPI
+TimerDriverGenerateSoftInterrupt (
+  IN EFI_TIMER_ARCH_PROTOCOL  *This
+  );
+
+///
+/// The handle onto which the Timer Architectural Protocol will be installed.
+///
+EFI_HANDLE   mTimerHandle = NULL;
+
+///
+/// The Timer Architectural Protocol that this driver produces.
+///
+EFI_TIMER_ARCH_PROTOCOL  mTimer = {
+  TimerDriverRegisterHandler,
+  TimerDriverSetTimerPeriod,
+  TimerDriverGetTimerPeriod,
+  TimerDriverGenerateSoftInterrupt
+};
+
+///
+/// Pointer to the CPU Architectural Protocol instance.
+///
+EFI_CPU_ARCH_PROTOCOL  *mCpu = NULL;
+
+///
+/// The notification function to call on every timer interrupt.
+///
+EFI_TIMER_NOTIFY  mTimerNotifyFunction = NULL;
+
+///
+/// The current period of the LAPIC timer interrupt in 100 ns units.
+///
+UINT64  mTimerPeriod = 0;
+
+///
+/// The number of TSC counts per second.
+///
+UINT64  mTscFrequency;
+
+/**
+  Read from an LAPIC register.
+
+  This function reads from a LAPIC register either in xAPIC or x2APIC mode.
+  It is required that in xAPIC mode wider registers (64-bit or 256-bit) must be
+  accessed using multiple 32-bit loads or stores, so this function only performs
+  32-bit read.
+
+  @param  MmioOffset  The MMIO offset of the LAPIC register in xAPIC mode.
+                      It must be 16-byte aligned.
+
+  @return 32-bit      Value read from the register.
+**/
+STATIC
+UINT32
+EFIAPI
+ReadLocalApicReg (
+  IN UINTN  MmioOffset
+  )
+{
+  UINT32 MsrIndex;
+
+  ASSERT ((MmioOffset & 0xf) == 0);
+
+  if (GetApicMode () == LOCAL_APIC_MODE_XAPIC) {
+    return MmioRead32 (GetLocalApicBaseAddress() + MmioOffset);
+  } else {
+    //
+    // DFR is not supported in x2APIC mode.
+    //
+    ASSERT (MmioOffset != XAPIC_ICR_DFR_OFFSET);
+    //
+    // Note that in x2APIC mode, ICR is a 64-bit MSR that needs special treatment. It
+    // is not supported in this function for simplicity.
+    //
+    ASSERT (MmioOffset != XAPIC_ICR_HIGH_OFFSET);
+
+    MsrIndex = (UINT32)(MmioOffset >> 4) + X2APIC_MSR_BASE_ADDRESS;
+    return AsmReadMsr32 (MsrIndex);
+  }
+}
+
+/**
+  Write to an LAPIC register.
+
+  This function writes to a LAPIC register either in xAPIC or x2APIC mode.
+  It is required that in xAPIC mode wider registers (64-bit or 256-bit) must be
+  accessed using multiple 32-bit loads or stores, so this function only performs
+  32-bit write.
+
+  if the register index is invalid or unsupported in current APIC mode, then ASSERT.
+
+  @param  MmioOffset  The MMIO offset of the LAPIC register in xAPIC mode.
+                      It must be 16-byte aligned.
+  @param  Value       Value to be written to the register.
+**/
+STATIC
+VOID
+EFIAPI
+WriteLocalApicReg (
+  IN UINTN  MmioOffset,
+  IN UINT32 Value
+  )
+{
+  UINT32 MsrIndex;
+
+  ASSERT ((MmioOffset & 0xf) == 0);
+
+  if (GetApicMode () == LOCAL_APIC_MODE_XAPIC) {
+    MmioWrite32 (GetLocalApicBaseAddress() + MmioOffset, Value);
+  } else {
+    //
+    // DFR is not supported in x2APIC mode.
+    //
+    ASSERT (MmioOffset != XAPIC_ICR_DFR_OFFSET);
+    //
+    // Note that in x2APIC mode, ICR is a 64-bit MSR that needs special treatment. It
+    // is not supported in this function for simplicity.
+    //
+    ASSERT (MmioOffset != XAPIC_ICR_HIGH_OFFSET);
+    ASSERT (MmioOffset != XAPIC_ICR_LOW_OFFSET);
+
+    MsrIndex =  (UINT32)(MmioOffset >> 4) + X2APIC_MSR_BASE_ADDRESS;
+    //
+    // The serializing semantics of WRMSR are relaxed when writing to the APIC registers.
+    // Use memory fence here to force the serializing semantics to be consistent with xAPIC mode.
+    //
+    MemoryFence ();
+    AsmWriteMsr32 (MsrIndex, Value);
+  }
+}
+
+/**
+  Write to MSR_IA32_TSC_DEADLINE register.
+
+  @param  Value       The 64-bit value to write to the MSR.
+**/
+STATIC
+VOID
+EFIAPI
+WriteTscDeadlineReg (
+  IN UINT64 Value
+  )
+{
+  MemoryFence ();
+  AsmWriteMsr64 (MSR_IA32_TSC_DEADLINE, Value);
+}
+
+/**
+  Initialize the LAPIC timer in TSC-deadline mode.
+
+  The LAPIC timer is initialized and disabled.
+**/
+VOID
+EFIAPI
+InitializeApicTimerDeadlineMode (
+  VOID
+  )
+{
+  LOCAL_APIC_LVT_TIMER LvtTimer;
+  //
+  // Ensure LAPIC is in software-enabled state.
+  //
+  InitializeLocalApicSoftwareEnable (TRUE);
+
+  //
+  // Disable APIC timer interrupt in deadline mode.
+  //
+  LvtTimer.Uint32 = ReadLocalApicReg (XAPIC_LVT_TIMER_OFFSET);
+  LvtTimer.Bits.TimerMode = 2;
+  LvtTimer.Bits.Mask = 1;
+  LvtTimer.Bits.Vector = 64;
+  WriteLocalApicReg (XAPIC_LVT_TIMER_OFFSET, LvtTimer.Uint32);
+}
+
+/**
+  The interrupt handler for an LAPIC timer.
+
+  @param  InterruptType  The type of interrupt that occurred.
+  @param  SystemContext  A pointer to the system context when the interrupt occurred.
+**/
+VOID
+EFIAPI
+TimerInterruptHandler (
+  IN EFI_EXCEPTION_TYPE   InterruptType,
+  IN EFI_SYSTEM_CONTEXT   SystemContext
+  )
+{
+  EFI_TPL Tpl;
+  UINT64  TimerCount;
+
+  //
+  // DXE core uses this callback for the EFI timer tick. The DXE core uses locks
+  // that raise to TPL_HIGH and then restore back to current level. Thus we need
+  // to make sure TPL level is set to TPL_HIGH while we are handling the timer tick.
+  //
+  Tpl = gBS->RaiseTPL (TPL_HIGH_LEVEL);
+
+  //
+  // Send EOI
+  //
+  SendApicEoi ();
+
+  if (mTimerPeriod != 0) {
+    // TimerCount = TimerPeriod in 100ns unit x Frequency
+    //            = TimerPeriod.10^-7 x Frequency
+    //            = (TimerPeriod x Frequency) x 10^-7
+    TimerCount = (UINT32)DivU64x32 (
+              MultU64x64 (
+                mTscFrequency,
+                mTimerPeriod
+                ), 10000000U
+              ) + AsmReadTsc();
+  } else {
+    TimerCount = 0;
+  }
+
+  WriteTscDeadlineReg (TimerCount);
+
+  if (mTimerNotifyFunction != NULL) {
+    mTimerNotifyFunction (mTimerPeriod);
+  }
+
+  gBS->RestoreTPL (Tpl);
+}
+
+/**
+  This function registers the handler NotifyFunction so it is called every time
+  the timer interrupt fires.  It also passes the amount of time since the last
+  handler call to the NotifyFunction.  If NotifyFunction is NULL, then the
+  handler is unregistered.  If the handler is registered, then EFI_SUCCESS is
+  returned.  If the CPU does not support registering a timer interrupt handler,
+  then EFI_UNSUPPORTED is returned.  If an attempt is made to register a handler
+  when a handler is already registered, then EFI_ALREADY_STARTED is returned.
+  If an attempt is made to unregister a handler when a handler is not registered,
+  then EFI_INVALID_PARAMETER is returned.  If an error occurs attempting to
+  register the NotifyFunction with the timer interrupt, then EFI_DEVICE_ERROR
+  is returned.
+
+  @param  This            The EFI_TIMER_ARCH_PROTOCOL instance.
+  @param  NotifyFunction  The function to call when a timer interrupt fires.
+                          This function executes at TPL_HIGH_LEVEL.  The DXE
+                          Core will register a handler for the timer interrupt,
+                          so it can know how much time has passed.  This
+                          information is used to signal timer based events.
+                          NULL will unregister the handler.
+
+  @retval  EFI_SUCCESS            The timer handler was registered.
+  @retval  EFI_UNSUPPORTED        The platform does not support timer interrupts.
+  @retval  EFI_ALREADY_STARTED    NotifyFunction is not NULL, and a handler is already
+                                  registered.
+  @retval  EFI_INVALID_PARAMETER  NotifyFunction is NULL, and a handler was not
+                                  previously registered.
+  @retval  EFI_DEVICE_ERROR       The timer handler could not be registered.
+
+**/
+EFI_STATUS
+EFIAPI
+TimerDriverRegisterHandler (
+  IN EFI_TIMER_ARCH_PROTOCOL  *This,
+  IN EFI_TIMER_NOTIFY         NotifyFunction
+  )
+{
+  //
+  // Check for invalid parameters
+  //
+  if (NotifyFunction == NULL && mTimerNotifyFunction == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+  if (NotifyFunction != NULL && mTimerNotifyFunction != NULL) {
+    return EFI_ALREADY_STARTED;
+  }
+
+  //
+  // Cache the registered notification function
+  //
+  mTimerNotifyFunction = NotifyFunction;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This function adjusts the period of timer interrupts to the value specified
+  by TimerPeriod.  If the timer period is updated, then the selected timer
+  period is stored in EFI_TIMER.TimerPeriod, and EFI_SUCCESS is returned.  If
+  the timer hardware is not programmable, then EFI_UNSUPPORTED is returned.
+  If an error occurs while attempting to update the timer period, then the
+  timer hardware will be put back in its state prior to this call, and
+  EFI_DEVICE_ERROR is returned.  If TimerPeriod is 0, then the timer interrupt
+  is disabled.  This is not the same as disabling the CPU's interrupts.
+  Instead, it must either turn off the timer hardware, or it must adjust the
+  interrupt controller so that a CPU interrupt is not generated when the timer
+  interrupt fires.
+
+  @param  This         The EFI_TIMER_ARCH_PROTOCOL instance.
+  @param  TimerPeriod  The rate to program the timer interrupt in 100 nS units.
+                       If the timer hardware is not programmable, then
+                       EFI_UNSUPPORTED is returned.  If the timer is programmable,
+                       then the timer period will be rounded up to the nearest
+                       timer period that is supported by the timer hardware.
+                       If TimerPeriod is set to 0, then the timer interrupts
+                       will be disabled.
+
+  @retval  EFI_SUCCESS       The timer period was changed.
+  @retval  EFI_UNSUPPORTED   The platform cannot change the period of the timer interrupt.
+  @retval  EFI_DEVICE_ERROR  The timer period could not be changed due to a device error.
+
+**/
+EFI_STATUS
+EFIAPI
+TimerDriverSetTimerPeriod (
+  IN EFI_TIMER_ARCH_PROTOCOL  *This,
+  IN UINT64                   TimerPeriod
+  )
+{
+  EFI_TPL Tpl;
+  UINT64  TimerCount;
+
+  Tpl = gBS->RaiseTPL (TPL_HIGH_LEVEL);
+
+  //
+  // Disable LAPIC timer when adjusting the timer period
+  //
+  DisableApicTimerInterrupt ();
+  WriteTscDeadlineReg (0);
+
+  if (TimerPeriod != 0) {
+    // TimerCount = TimerPeriod in 100ns unit x Frequency
+    //            = TimerPeriod.10^-7 x Frequency
+    //            = (TimerPeriod x Frequency) x 10^-7
+    TimerCount = (UINT32)DivU64x32 (
+              MultU64x64 (
+                mTscFrequency,
+                TimerPeriod
+                ), 10000000U
+              ) + AsmReadTsc();
+
+    EnableApicTimerInterrupt ();
+    WriteTscDeadlineReg (TimerCount);
+  }
+
+  //
+  // Save the new timer period
+  //
+  mTimerPeriod = TimerPeriod;
+
+  gBS->RestoreTPL (Tpl);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This function retrieves the period of timer interrupts in 100 ns units,
+  returns that value in TimerPeriod, and returns EFI_SUCCESS.  If TimerPeriod
+  is NULL, then EFI_INVALID_PARAMETER is returned.  If a TimerPeriod of 0 is
+  returned, then the timer is currently disabled.
+
+  @param  This         The EFI_TIMER_ARCH_PROTOCOL instance.
+  @param  TimerPeriod  A pointer to the timer period to retrieve in 100 ns units.
+                       If 0 is returned, then the timer is currently disabled.
+
+  @retval  EFI_SUCCESS            The timer period was returned in TimerPeriod.
+  @retval  EFI_INVALID_PARAMETER  TimerPeriod is NULL.
+
+**/
+EFI_STATUS
+EFIAPI
+TimerDriverGetTimerPeriod (
+  IN EFI_TIMER_ARCH_PROTOCOL   *This,
+  OUT UINT64                   *TimerPeriod
+  )
+{
+  if (TimerPeriod == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *TimerPeriod = mTimerPeriod;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This function generates a soft timer interrupt. If the platform does not support soft
+  timer interrupts, then EFI_UNSUPPORTED is returned. Otherwise, EFI_SUCCESS is returned.
+  If a handler has been registered through the EFI_TIMER_ARCH_PROTOCOL.RegisterHandler()
+  service, then a soft timer interrupt will be generated. If the timer interrupt is
+  enabled when this service is called, then the registered handler will be invoked. The
+  registered handler should not be able to distinguish a hardware-generated timer
+  interrupt from a software-generated timer interrupt.
+
+  @param  This  The EFI_TIMER_ARCH_PROTOCOL instance.
+
+  @retval  EFI_SUCCESS       The soft timer interrupt was generated.
+  @retval  EFI_UNSUPPORTED   The platform does not support the generation of soft
+                             timer interrupts.
+
+**/
+EFI_STATUS
+EFIAPI
+TimerDriverGenerateSoftInterrupt (
+  IN EFI_TIMER_ARCH_PROTOCOL  *This
+  )
+{
+  EFI_TPL    Tpl;
+  EFI_STATUS Status = EFI_SUCCESS;
+
+  Tpl = gBS->RaiseTPL (TPL_HIGH_LEVEL);
+
+  //
+  // If the timer interrupt is enabled, then the registered handler will be invoked.
+  //
+  if (GetApicTimerInterruptState ()) {
+    if (mTimerNotifyFunction != NULL) {
+      mTimerNotifyFunction (mTimerPeriod);
+    }
+  } else {
+    Status = EFI_UNSUPPORTED;
+  }
+
+  gBS->RestoreTPL (Tpl);
+
+  return Status;
+}
+
+/**
+  Initialize the Timer Architectural Protocol driver
+
+  @param  ImageHandle  ImageHandle of the loaded driver
+  @param  SystemTable  Pointer to the System Table
+
+  @retval  EFI_SUCCESS           Timer Architectural Protocol created
+  @retval  EFI_OUT_OF_RESOURCES  Not enough resources available to initialize driver.
+  @retval  EFI_DEVICE_ERROR      A device error occurred attempting to initialize the driver.
+
+**/
+EFI_STATUS
+EFIAPI
+TimerDriverInitialize (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS                             Status;
+  CPUID_VERSION_INFO_ECX                 Ecx;
+
+  DEBUG ((DEBUG_INFO, "Initializing LAPIC Timer Driver\n"));
+
+  //
+  // Make sure the Timer Architectural Protocol is not already installed in the system
+  //
+  ASSERT_PROTOCOL_ALREADY_INSTALLED (NULL, &gEfiTimerArchProtocolGuid);
+
+  //
+  // Find the CPU architectural protocol.
+  //
+  Status = gBS->LocateProtocol (&gEfiCpuArchProtocolGuid, NULL, (VOID **) &mCpu);
+  ASSERT_EFI_ERROR (Status);
+
+  //
+  // Check if LAPIC supports TSC-deadine mode
+  //
+  AsmCpuid (CPUID_VERSION_INFO, NULL, NULL, &Ecx.Uint32, NULL);
+  if (Ecx.Bits.TSC_Deadline == 0) {
+    DEBUG ((DEBUG_ERROR, "LAPIC TSC-deadine mode is not supported. Unload LAPIC timer driver.\n"));
+    return EFI_DEVICE_ERROR;
+  }
+
+  //
+  // Get TSC frequency
+  //
+  mTscFrequency = (UINT64) PcdGet32 (PcdFSBClock);
+
+  //
+  // Disable LAPIC timer during initialization
+  //
+  InitializeApicTimerDeadlineMode ();
+
+  //
+  // Install interrupt handler
+  //
+  Status = mCpu->RegisterInterruptHandler (mCpu, 64, TimerInterruptHandler);
+  ASSERT_EFI_ERROR (Status);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Unable to register LAPIC interrupt with CPU Arch Protocol. Unload LAPIC timer driver.\n"));
+    return EFI_DEVICE_ERROR;
+  }
+
+  //
+  // Force the LAPIC Timer to be enabled
+  //
+  Status = TimerDriverSetTimerPeriod (&mTimer, 1000000);
+  ASSERT_EFI_ERROR (Status);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Unable to set LAPIC default timer period. Unload LAPIC timer driver.\n"));
+    return EFI_DEVICE_ERROR;
+  }
+
+  //
+  // Install the Timer Architectural Protocol onto a new handle
+  //
+  Status = gBS->InstallMultipleProtocolInterfaces (
+                  &mTimerHandle,
+                  &gEfiTimerArchProtocolGuid, &mTimer,
+                  NULL
+                  );
+  ASSERT_EFI_ERROR (Status);
+
+  return Status;
+}

--- a/OvmfPkg/AcrnLapicTimerDxe/AcrnLapicTimerDxe.inf
+++ b/OvmfPkg/AcrnLapicTimerDxe/AcrnLapicTimerDxe.inf
@@ -1,0 +1,54 @@
+## @file
+# Timer Architectural Protocol module using Local Advanced Programmable Interrupt
+# Controller (LAPIC) Timer.
+#
+# Copyright (c) 2011 - 2020, Intel Corporation. All rights reserved.<BR>
+# This program and the accompanying materials
+# are licensed and made available under the terms and conditions of the BSD License
+# which accompanies this distribution.  The full text of the license may be found at
+# http://opensource.org/licenses/bsd-license.php
+#
+# THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+# WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = AcrnLapicTimerDxe
+  FILE_GUID                      = A7D023B1-B02A-4EBE-A801-D2F2630CF807
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = TimerDriverInitialize
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  AcrnLapicTimer.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
+
+[LibraryClasses]
+  PcdLib
+  IoLib
+  DebugLib
+  UefiDriverEntryPoint
+  UefiBootServicesTableLib
+  BaseLib
+  LocalApicLib
+
+[Protocols]
+  gEfiTimerArchProtocolGuid                     ## PRODUCES
+  gEfiCpuArchProtocolGuid                       ## CONSUMES
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdFSBClock                      ## SOMETIMES_CONSUMES
+
+[Depex]
+  gEfiCpuArchProtocolGuid

--- a/OvmfPkg/Library/AcrnTscTimerLib/AcrnTscTimerLib.c
+++ b/OvmfPkg/Library/AcrnTscTimerLib/AcrnTscTimerLib.c
@@ -1,0 +1,231 @@
+/** @file
+  The Timer Library implementation which uses the Time Stamp Counter in the processor.
+
+  For Pentium 4 processors, Intel Xeon processors (family [0FH], models [03H and higher]);
+    for Intel Core Solo and Intel Core Duo processors (family [06H], model [0EH]);
+    for the Intel Xeon processor 5100 series and Intel Core 2 Duo processors (family [06H], model [0FH]);
+    for Intel Core 2 and Intel Xeon processors (family [06H], display_model [17H]);
+    for Intel Atom processors (family [06H], display_model [1CH]):
+  the time-stamp counter increments at a constant rate.
+  That rate may be set by the maximum core-clock to bus-clock ratio of the processor or may be set by
+  the maximum resolved frequency at which the processor is booted. The maximum resolved frequency may
+  differ from the maximum qualified frequency of the processor.
+
+  The specific processor configuration determines the behavior. Constant TSC behavior ensures that the
+  duration of each clock tick is uniform and supports the use of the TSC as a wall clock timer even if
+  the processor core changes frequency. This is the architectural behavior moving forward.
+
+  A Processor's support for invariant TSC is indicated by CPUID.0x80000007.EDX[8].
+
+  Copyright (c) 2009 - 2020, Intel Corporation. All rights reserved.<BR>
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution. The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+
+#include <Library/TimerLib.h>
+#include <Library/BaseLib.h>
+#include <Library/PcdLib.h>
+
+/**  Get TSC frequency.
+
+  @return The number of TSC counts per second.
+
+**/
+UINT64
+InternalGetTscFrequency (
+  VOID
+  )
+{
+  return PcdGet32 (PcdFSBClock);
+}
+
+/**  Stalls the CPU for at least the given number of ticks.
+
+  Stalls the CPU for at least the given number of ticks. It's invoked by
+  MicroSecondDelay() and NanoSecondDelay().
+
+  @param[in]  Delay     A period of time to delay in ticks.
+
+**/
+VOID
+InternalX86Delay (
+  IN      UINT64                    Delay
+  )
+{
+  UINT64                             Ticks;
+
+  //
+  // The target timer count is calculated here
+  //
+  Ticks = AsmReadTsc() + Delay;
+
+  //
+  // Wait until time out
+  // Timer wrap-arounds are NOT handled correctly by this function.
+  // Thus, this function must be called within 10 years of reset since
+  // Intel guarantees a minimum of 10 years before the TSC wraps.
+  //
+  while (AsmReadTsc() <= Ticks) CpuPause();
+}
+
+/**  Stalls the CPU for at least the specified number of MicroSeconds.
+
+  @param[in]  MicroSeconds  The minimum number of microseconds to delay.
+
+  @return The value of MicroSeconds input.
+
+**/
+UINTN
+EFIAPI
+MicroSecondDelay (
+  IN      UINTN                     MicroSeconds
+  )
+{
+  InternalX86Delay (
+    DivU64x32 (
+      MultU64x64 (
+        InternalGetTscFrequency (),
+        MicroSeconds
+      ),
+      1000000u
+    )
+  );
+  return MicroSeconds;
+}
+
+/**  Stalls the CPU for at least the specified number of NanoSeconds.
+
+  @param[in]  NanoSeconds The minimum number of nanoseconds to delay.
+
+  @return The value of NanoSeconds input.
+
+**/
+UINTN
+EFIAPI
+NanoSecondDelay (
+  IN      UINTN                     NanoSeconds
+  )
+{
+  InternalX86Delay (
+    DivU64x32 (
+      MultU64x32 (
+        InternalGetTscFrequency (),
+        (UINT32)NanoSeconds
+      ),
+      1000000000u
+    )
+  );
+  return NanoSeconds;
+}
+
+/**  Retrieves the current value of the 64-bit free running Time-Stamp counter.
+
+  The time-stamp counter (as implemented in the P6 family, Pentium, Pentium M,
+  Pentium 4, Intel Xeon, Intel Core Solo and Intel Core Duo processors and
+  later processors) is a 64-bit counter that is set to 0 following a RESET of
+  the processor.  Following a RESET, the counter increments even when the
+  processor is halted by the HLT instruction or the external STPCLK# pin. Note
+  that the assertion of the external DPSLP# pin may cause the time-stamp
+  counter to stop.
+
+  The properties of the counter can be retrieved by the
+  GetPerformanceCounterProperties() function.
+
+  @return The current value of the free running performance counter.
+
+**/
+UINT64
+EFIAPI
+GetPerformanceCounter (
+  VOID
+  )
+{
+  return AsmReadTsc();
+}
+
+/**  Retrieves the 64-bit frequency in Hz and the range of performance counter
+  values.
+
+  If StartValue is not NULL, then the value that the performance counter starts
+  with, 0x0, is returned in StartValue. If EndValue is not NULL, then the value
+  that the performance counter end with, 0xFFFFFFFFFFFFFFFF, is returned in
+  EndValue.
+
+  The 64-bit frequency of the performance counter, in Hz, is always returned.
+  To determine average processor clock frequency, Intel recommends the use of
+  EMON logic to count processor core clocks over the period of time for which
+  the average is required.
+
+
+  @param[out]   StartValue  Pointer to where the performance counter's starting value is saved, or NULL.
+  @param[out]   EndValue    Pointer to where the performance counter's ending value is saved, or NULL.
+
+  @return The frequency in Hz.
+
+**/
+UINT64
+EFIAPI
+GetPerformanceCounterProperties (
+  OUT      UINT64                    *StartValue,  OPTIONAL
+  OUT      UINT64                    *EndValue     OPTIONAL
+  )
+{
+  if (StartValue != NULL) {
+    *StartValue = 0;
+  }
+  if (EndValue != NULL) {
+    *EndValue = 0xFFFFFFFFFFFFFFFFull;
+  }
+
+  return InternalGetTscFrequency ();
+}
+
+/**
+  Converts elapsed ticks of performance counter to time in nanoseconds.
+
+  This function converts the elapsed ticks of running performance counter to
+  time value in unit of nanoseconds.
+
+  @param  Ticks     The number of elapsed ticks of running performance counter.
+
+  @return The elapsed time in nanoseconds.
+
+**/
+UINT64
+EFIAPI
+GetTimeInNanoSecond (
+  IN      UINT64                     Ticks
+  )
+{
+  UINT64  Frequency;
+  UINT64  NanoSeconds;
+  UINT64  Remainder;
+  INTN    Shift;
+
+  Frequency = GetPerformanceCounterProperties (NULL, NULL);
+
+  //
+  //          Ticks
+  // Time = --------- x 1,000,000,000
+  //        Frequency
+  //
+  NanoSeconds = MultU64x32 (DivU64x64Remainder (Ticks, Frequency, &Remainder), 1000000000u);
+
+  //
+  // Ensure (Remainder * 1,000,000,000) will not overflow 64-bit.
+  // Since 2^29 < 1,000,000,000 = 0x3B9ACA00 < 2^30, Remainder should < 2^(64-30) = 2^34,
+  // i.e. highest bit set in Remainder should <= 33.
+  //
+  Shift = MAX (0, HighBitSet64 (Remainder) - 33);
+  Remainder = RShiftU64 (Remainder, (UINTN) Shift);
+  Frequency = RShiftU64 (Frequency, (UINTN) Shift);
+  NanoSeconds += DivU64x64Remainder (MultU64x32 (Remainder, 1000000000u), Frequency, NULL);
+
+  return NanoSeconds;
+}

--- a/OvmfPkg/Library/AcrnTscTimerLib/AcrnTscTimerLib.inf
+++ b/OvmfPkg/Library/AcrnTscTimerLib/AcrnTscTimerLib.inf
@@ -1,0 +1,47 @@
+## @file
+# Instance of Timer Library which uses the Time Stamp Counter in the processor.
+#
+#  A version of the Timer Library using the processor's TSC.
+#  The time stamp counter in newer processors may support an enhancement, referred to as invariant TSC.
+#  The invariant TSC runs at a constant rate in all ACPI P-, C-. and T-states.
+#  This is the architectural behavior moving forward.
+#  TSC reads are much more efficient and do not incur the overhead associated with a ring transition or
+#  access to a platform resource.
+#
+# Copyright (c) 2010 - 2020, Intel Corporation. All rights reserved.<BR>
+#
+#  This program and the accompanying materials
+#  are licensed and made available under the terms and conditions of the BSD License
+#  which accompanies this distribution. The full text of the license may be found at
+#  http://opensource.org/licenses/bsd-license.php.
+#  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = AcrnTscTimerLib
+  FILE_GUID                      = D29338B9-50FE-4E4F-B7D4-A150A2C1F4FB
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = TimerLib
+
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  AcrnTscTimerLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  PcdLib
+  BaseLib
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdFSBClock  ## SOMETIMES_CONSUMES

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -111,7 +111,7 @@
 [LibraryClasses]
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
   #TimerLib|OvmfPkg/Library/AcpiTimerLib/BaseAcpiTimerLib.inf
-  TimerLib|UefiCpuPkg/Library/SecPeiDxeTimerLibUefiCpu/SecPeiDxeTimerLibUefiCpu.inf
+  TimerLib|OvmfPkg/Library/AcrnTscTimerLib/AcrnTscTimerLib.inf
   PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
   BaseMemoryLib|MdePkg/Library/BaseMemoryLibRepStr/BaseMemoryLibRepStr.inf
   BaseLib|MdePkg/Library/BaseLib/BaseLib.inf
@@ -231,7 +231,7 @@
 
 [LibraryClasses.common.SEC]
   #TimerLib|OvmfPkg/Library/AcpiTimerLib/BaseRomAcpiTimerLib.inf
-  TimerLib|UefiCpuPkg/Library/SecPeiDxeTimerLibUefiCpu/SecPeiDxeTimerLibUefiCpu.inf
+  TimerLib|OvmfPkg/Library/AcrnTscTimerLib/AcrnTscTimerLib.inf
   QemuFwCfgLib|OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgLibNull.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
@@ -320,7 +320,7 @@
   NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
   #TimerLib|OvmfPkg/Library/AcpiTimerLib/DxeAcpiTimerLib.inf
-  TimerLib|UefiCpuPkg/Library/SecPeiDxeTimerLibUefiCpu/SecPeiDxeTimerLibUefiCpu.inf
+  TimerLib|OvmfPkg/Library/AcrnTscTimerLib/AcrnTscTimerLib.inf
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
   DxeCoreEntryPoint|MdePkg/Library/DxeCoreEntryPoint/DxeCoreEntryPoint.inf
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
@@ -339,7 +339,7 @@
   NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
   #TimerLib|OvmfPkg/Library/AcpiTimerLib/DxeAcpiTimerLib.inf
-  TimerLib|UefiCpuPkg/Library/SecPeiDxeTimerLibUefiCpu/SecPeiDxeTimerLibUefiCpu.inf
+  TimerLib|OvmfPkg/Library/AcrnTscTimerLib/AcrnTscTimerLib.inf
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
   DxeCoreEntryPoint|MdePkg/Library/DxeCoreEntryPoint/DxeCoreEntryPoint.inf
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
@@ -356,7 +356,7 @@
   NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
   #TimerLib|OvmfPkg/Library/AcpiTimerLib/DxeAcpiTimerLib.inf
-  TimerLib|UefiCpuPkg/Library/SecPeiDxeTimerLibUefiCpu/SecPeiDxeTimerLibUefiCpu.inf
+  TimerLib|OvmfPkg/Library/AcrnTscTimerLib/AcrnTscTimerLib.inf
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
   ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
@@ -391,7 +391,7 @@
 [LibraryClasses.common.UEFI_APPLICATION]
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
   #TimerLib|OvmfPkg/Library/AcpiTimerLib/DxeAcpiTimerLib.inf
-  TimerLib|UefiCpuPkg/Library/SecPeiDxeTimerLibUefiCpu/SecPeiDxeTimerLibUefiCpu.inf
+  TimerLib|OvmfPkg/Library/AcrnTscTimerLib/AcrnTscTimerLib.inf
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
   ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
@@ -405,7 +405,7 @@
 [LibraryClasses.common.DXE_SMM_DRIVER]
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
   #TimerLib|OvmfPkg/Library/AcpiTimerLib/DxeAcpiTimerLib.inf
-  TimerLib|UefiCpuPkg/Library/SecPeiDxeTimerLibUefiCpu/SecPeiDxeTimerLibUefiCpu.inf
+  TimerLib|OvmfPkg/Library/AcrnTscTimerLib/AcrnTscTimerLib.inf
   MemoryAllocationLib|MdePkg/Library/SmmMemoryAllocationLib/SmmMemoryAllocationLib.inf
   ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
@@ -426,7 +426,7 @@
 [LibraryClasses.common.SMM_CORE]
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
   #TimerLib|OvmfPkg/Library/AcpiTimerLib/DxeAcpiTimerLib.inf
-  TimerLib|UefiCpuPkg/Library/SecPeiDxeTimerLibUefiCpu/SecPeiDxeTimerLibUefiCpu.inf
+  TimerLib|OvmfPkg/Library/AcrnTscTimerLib/AcrnTscTimerLib.inf
   SmmCorePlatformHookLib|MdeModulePkg/Library/SmmCorePlatformHookLibNull/SmmCorePlatformHookLibNull.inf
   MemoryAllocationLib|MdeModulePkg/Library/PiSmmCoreMemoryAllocationLib/PiSmmCoreMemoryAllocationLib.inf
   ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -712,7 +712,7 @@
   #PcAtChipsetPkg/8259InterruptControllerDxe/8259.inf
   UefiCpuPkg/CpuIo2Dxe/CpuIo2Dxe.inf
   UefiCpuPkg/CpuDxe/CpuDxe.inf
-  PcAtChipsetPkg/HpetTimerDxe/HpetTimerDxe.inf
+  OvmfPkg/AcrnLapicTimerDxe/AcrnLapicTimerDxe.inf
   #OvmfPkg/IncompatiblePciDeviceSupportDxe/IncompatiblePciDeviceSupport.inf
   #OvmfPkg/PciHotPlugInitDxe/PciHotPlugInit.inf
   MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf {

--- a/OvmfPkg/OvmfPkgX64.fdf
+++ b/OvmfPkg/OvmfPkgX64.fdf
@@ -217,7 +217,7 @@ INF  MdeModulePkg/Universal/SecurityStubDxe/SecurityStubDxe.inf
 #INF  PcAtChipsetPkg/8259InterruptControllerDxe/8259.inf
 INF  UefiCpuPkg/CpuIo2Dxe/CpuIo2Dxe.inf
 INF  UefiCpuPkg/CpuDxe/CpuDxe.inf
-INF  PcAtChipsetPkg/HpetTimerDxe/HpetTimerDxe.inf
+INF  OvmfPkg/AcrnLapicTimerDxe/AcrnLapicTimerDxe.inf
 #INF  OvmfPkg/IncompatiblePciDeviceSupportDxe/IncompatiblePciDeviceSupport.inf
 #INF  OvmfPkg/PciHotPlugInitDxe/PciHotPlugInit.inf
 INF  MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf

--- a/UefiCpuPkg/Include/Register/LocalApic.h
+++ b/UefiCpuPkg/Include/Register/LocalApic.h
@@ -1,7 +1,7 @@
 /** @file
   IA32 Local APIC Definitions.
 
-  Copyright (c) 2010 - 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2010 - 2020, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -130,8 +130,8 @@ typedef union {
     UINT32  DeliveryStatus:1;  ///< 0: Idle, 1: send pending.
     UINT32  Reserved1:3;       ///< Reserved.
     UINT32  Mask:1;            ///< 0: Not masked, 1: Masked.
-    UINT32  TimerMode:1;       ///< 0: One-shot, 1: Periodic.
-    UINT32  Reserved2:14;      ///< Reserved.
+    UINT32  TimerMode:2;       ///< 0: One-shot, 1: Periodic, 2: TSC-deadline.
+    UINT32  Reserved2:13;      ///< Reserved.
   } Bits;
   UINT32    Uint32;
 } LOCAL_APIC_LVT_TIMER;


### PR DESCRIPTION
A series of patches to implement and enable lapic timer driver using deadline mode.
Using lapic timer with deadline mode have conflict with existing X86timer library for delay purpose. Add back TSC based delay timer.