### PR TITLE
GvtGopDxe: Adjust the offset of gop in pvinfo page

### DIFF
--- a/OvmfPkg/GvtGopDxe/Gop.h
+++ b/OvmfPkg/GvtGopDxe/Gop.h
@@ -25,8 +25,8 @@
 #define VGT_MAGIC               0x4776544776544776ULL /* 'vGTvGTvG' */
 #define VGT_IF_BASE             0x78000
 #define VGT_G2V_OFFSET          0x818
-#define VGT_GOP_OFFSET          0x86C
-#define VGT_G2V_GOP_SETUP       0xd
+#define VGT_GOP_OFFSET          0x860
+#define VGT_G2V_GOP_SETUP       0x8
 
 /* GVT_IF_HDR is part of vgt_if in gvt linux kernel driver */
 


### PR DESCRIPTION
For the purpose to use same code base with kvmgt, the gop driver
need to use different offset of the gop struct in the pvinfo page.
This patch is used to adjust offset and hence align to kvmgt.

Tracked-On: projectacrn/acrn-hypervisor#5297
Signed-off-by: Xiaoguang Wu <xiaoguang.wu@intel.com>