### PR TITLE
ovmf: reserve e820 table for PTCM

### DIFF
--- a/OvmfPkg/PlatformPei/Acrn.c
+++ b/OvmfPkg/PlatformPei/Acrn.c
@@ -198,6 +198,13 @@ AcrnPublishRamRegions (
 
   for (Loop = 0, Entry = &E820->E820Map[Loop]; Loop < E820->E820EntriesCount;
        Entry = &E820->E820Map[++Loop]) {
+
+    /*WA: For PTCM */
+    if ((Entry->Type == EfiAcpiAddressRangeReserved) && (Entry->BaseAddr == 0x40080000UL)) {
+      AddReservedMemoryBaseSizeHob(Entry->BaseAddr, Entry->Length, 0);
+      continue;
+    }
+
     //
     // Only care about RAM
     //


### PR DESCRIPTION
Reserve e820 table for PTCM support.

Tracked-On: projectacrn/acrn-hypervisor#5330
Signed-off-by: Li Fei1 <fei1.li@intel.com>