### PR TITLE
Remove set of CR4.MCE by default

### DIFF
--- a/UefiCpuPkg/ResetVector/Vtf0/Ia16/Real16ToFlat32.asm
+++ b/UefiCpuPkg/ResetVector/Vtf0/Ia16/Real16ToFlat32.asm
@@ -14,7 +14,7 @@
 ;------------------------------------------------------------------------------
 
 %define SEC_DEFAULT_CR0  0x40000023
-%define SEC_DEFAULT_CR4  0x640
+%define SEC_DEFAULT_CR4  0x600
 
 BITS    16
 


### PR DESCRIPTION
 If CR4.MCE is set by default, OVFM boots fail if
 hypervisor does not expose MCE support for guest VM.

 This patch unset CR4.MCE by default.

Signed-off-by: Yonghua Huang <yonghua.huang@intel.com>