### PR TITLE
Change 64-bit MMIO BAR window to 256G-512G

### DIFF
--- a/OvmfPkg/PlatformPei/Acrn.c
+++ b/OvmfPkg/PlatformPei/Acrn.c
@@ -143,8 +143,8 @@ AcrnFindPciMmio64Aperture (
   OUT  UINT64               *Pci64Size
   )
 {
-  *Pci64Base = BASE_4GB;
-  *Pci64Size = SIZE_1GB;
+  *Pci64Base = BASE_256GB;
+  *Pci64Size = SIZE_256GB;
 
   return RETURN_SUCCESS;
 }


### PR DESCRIPTION
DM maps 64-bit mmio BARs of vdev into 4G-5G, for post-launched VMs. At native
platform, 64-bit MMIO BARs which have 39-bit address, are always mapped into
256G-512G address space.
DM will change the address window of 64-bit vdev BARs of post-launched VMs to
256G-512G. That ask OVMF to do the same change, to boot from passthrough SATA/MVME
disks, which have 64-bit MMIO BAR.

Tracked-On: #5913
Signed-off-by: Tao Yuhong <yuhong.tao@intel.com>