### PR TITLE
VGA interface of virtio-gpu adapter support

### DIFF
--- a/MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsole.c
+++ b/MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsole.c
@@ -432,6 +432,8 @@ GraphicsConsoleControllerDriverStart (
 
   HorizontalResolution  = PcdGet32 (PcdVideoHorizontalResolution);
   VerticalResolution    = PcdGet32 (PcdVideoVerticalResolution);
+  HorizontalResolution  = 1024;
+  VerticalResolution    = 768;
 
   if (Private->GraphicsOutput != NULL) {
     //

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -790,7 +790,7 @@
   MdeModulePkg/Universal/DisplayEngineDxe/DisplayEngineDxe.inf
   #MdeModulePkg/Universal/MemoryTest/NullMemoryTestDxe/NullMemoryTestDxe.inf
 
-  #OvmfPkg/QemuVideoDxe/QemuVideoDxe.inf
+  OvmfPkg/QemuVideoDxe/QemuVideoDxe.inf
   #OvmfPkg/QemuRamfbDxe/QemuRamfbDxe.inf
   #OvmfPkg/VirtioGpuDxe/VirtioGpu.inf
 

--- a/OvmfPkg/OvmfPkgX64.fdf
+++ b/OvmfPkg/OvmfPkgX64.fdf
@@ -354,7 +354,7 @@ INF  IntelFrameworkModulePkg/Csm/LegacyBiosDxe/LegacyBiosDxe.inf
 INF  RuleOverride=CSM OvmfPkg/Csm/Csm16/Csm16.inf
 !endif
 
-#INF  OvmfPkg/QemuVideoDxe/QemuVideoDxe.inf
+INF  OvmfPkg/QemuVideoDxe/QemuVideoDxe.inf
 #INF  OvmfPkg/QemuRamfbDxe/QemuRamfbDxe.inf
 #INF  OvmfPkg/VirtioGpuDxe/VirtioGpu.inf
 INF  OvmfPkg/PlatformDxe/Platform.inf

--- a/OvmfPkg/QemuVideoDxe/VbeShim.c
+++ b/OvmfPkg/QemuVideoDxe/VbeShim.c
@@ -152,6 +152,7 @@ InstallVbeShim (
   HostBridgeDevId = PcdGet16 (PcdOvmfHostBridgePciDevId);
   switch (HostBridgeDevId) {
   case INTEL_82441_DEVICE_ID:
+  case ACRN_HOSTBRIDGE_DEVICE_ID:
     Pam1Address = PMC_REGISTER_PIIX4 (PIIX4_PAM1);
     break;
   case INTEL_Q35_MCH_DEVICE_ID:


### PR DESCRIPTION
QemuVideoDxe is opensource VGA GOP driver in OVMF. This driver can
support any adpater followed virtio-vga spec. Default resolution is
1024x768.
https://git.qemu.org/?p=qemu.git;a=blob;f=docs/specs/standard-vga.txt;hb=HEAD

Signed-off-by: Sun Peng <peng.p.sun@linux.intel.com>
Reviewed-by: Zhao Yakui <yakui.zhao@intel.com>