### PR TITLE
Vga gop

### DIFF
--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -573,8 +573,8 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase|0
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase|0
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciDisableBusEnumeration|TRUE
-  gEfiMdeModulePkgTokenSpaceGuid.PcdVideoHorizontalResolution|800
-  gEfiMdeModulePkgTokenSpaceGuid.PcdVideoVerticalResolution|600
+  gEfiMdeModulePkgTokenSpaceGuid.PcdVideoHorizontalResolution|1024
+  gEfiMdeModulePkgTokenSpaceGuid.PcdVideoVerticalResolution|768
   #gEfiMdeModulePkgTokenSpaceGuid.PcdConOutRow|0
   #gEfiMdeModulePkgTokenSpaceGuid.PcdConOutColumn|0
 
@@ -790,7 +790,7 @@
   MdeModulePkg/Universal/DisplayEngineDxe/DisplayEngineDxe.inf
   #MdeModulePkg/Universal/MemoryTest/NullMemoryTestDxe/NullMemoryTestDxe.inf
 
-  #OvmfPkg/QemuVideoDxe/QemuVideoDxe.inf
+  OvmfPkg/QemuVideoDxe/QemuVideoDxe.inf
   #OvmfPkg/QemuRamfbDxe/QemuRamfbDxe.inf
   #OvmfPkg/VirtioGpuDxe/VirtioGpu.inf
 

--- a/OvmfPkg/OvmfPkgX64.fdf
+++ b/OvmfPkg/OvmfPkgX64.fdf
@@ -354,7 +354,7 @@ INF  IntelFrameworkModulePkg/Csm/LegacyBiosDxe/LegacyBiosDxe.inf
 INF  RuleOverride=CSM OvmfPkg/Csm/Csm16/Csm16.inf
 !endif
 
-#INF  OvmfPkg/QemuVideoDxe/QemuVideoDxe.inf
+INF  OvmfPkg/QemuVideoDxe/QemuVideoDxe.inf
 #INF  OvmfPkg/QemuRamfbDxe/QemuRamfbDxe.inf
 #INF  OvmfPkg/VirtioGpuDxe/VirtioGpu.inf
 INF  OvmfPkg/PlatformDxe/Platform.inf

--- a/OvmfPkg/PlatformPei/Acrn.c
+++ b/OvmfPkg/PlatformPei/Acrn.c
@@ -67,10 +67,10 @@ AcrnGetSystemMemorySizeBelow4gb (
   // ACRN e820 tables are sorted and the low memory address
   // is start larger than 1MB
   //
-  for (loop = 0; loop < E820->E820EntriesCount; loop++) {
+  for (Loop = 0; Loop < E820->E820EntriesCount; Loop++) {
     Entry = &E820->E820Map[Loop];
-    if (Entry->Type == EfiAcpiAddressRangeMemory &&
-        Entry->BaseAddr >= 0x100000)
+    if ((Entry->Type == EfiAcpiAddressRangeMemory) &&
+        (Entry->BaseAddr >= 0x100000)) {
       *MemSize = Entry->BaseAddr + Entry->Length;
       return RETURN_SUCCESS;
     }

--- a/OvmfPkg/QemuVideoDxe/VbeShim.c
+++ b/OvmfPkg/QemuVideoDxe/VbeShim.c
@@ -152,6 +152,7 @@ InstallVbeShim (
   HostBridgeDevId = PcdGet16 (PcdOvmfHostBridgePciDevId);
   switch (HostBridgeDevId) {
   case INTEL_82441_DEVICE_ID:
+  case ACRN_HOSTBRIDGE_DEVICE_ID:
     Pam1Address = PMC_REGISTER_PIIX4 (PIIX4_PAM1);
     break;
   case INTEL_Q35_MCH_DEVICE_ID:


### PR DESCRIPTION
QemuVideoDxe is opensource VGA GOP driver in OVMF. This driver can
support any adpater followed virtio-vga spec. Default resolution is
1024x768.
https://git.qemu.org/?p=qemu.git;a=blob;f=docs/specs/standard-vga.txt;hb=HEAD