### PR TITLE
Ovmf rom bar

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -319,6 +319,10 @@ PciSearchDevice (
 
     ResetPowerManagementFeature (PciIoDevice);
 
+  } else {
+    if (!IS_CARDBUS_BRIDGE (Pci)) {
+      GetOpRomInfo (PciIoDevice);
+    }
   }
 
   //
@@ -1173,12 +1177,19 @@ ProcessOptionRomLight (
       ProcessOptionRomLight (Temp);
     }
 
-    PciRomGetImageMapping (Temp);
+    if (!IS_CARDBUS_BRIDGE (&Temp->Pci) && (Temp->RomSize != 0)) {
+      LoadOpRomImageLight(Temp);
+      Temp->AllOpRomProcessed = FALSE;
+    } else {
+    //  When Rom_size is zero, it is not found in mRootImageTable.
+    //  It is unnecessary to call the PciRomGetImageMapping.
+    //  PciRomGetImageMapping (Temp);
 
     //
     // The OpRom has already been processed in the first round
     //
-    Temp->AllOpRomProcessed = TRUE;
+      Temp->AllOpRomProcessed = TRUE;
+    }
 
     CurrentLink = CurrentLink->ForwardLink;
   }

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciOptionRomSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciOptionRomSupport.c
@@ -243,6 +243,7 @@ GetOpRomInfo (
   UINT8                           Bus;
   UINT8                           Device;
   UINT8                           Function;
+  UINT8                           OriginalValue;
   EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL *PciRootBridgeIo;
 
   Bus             = PciIoDevice->BusNumber;
@@ -266,6 +267,14 @@ GetOpRomInfo (
     //
     RomBarIndex = PCI_BRIDGE_ROMBAR;
   }
+  // Read the Original value
+  Address = EFI_PCI_ADDRESS (Bus, Device, Function, RomBarIndex);
+  PciRootBridgeIo->Pci.Read(PciRootBridgeIo,
+                            EfiPciWidthUint32,
+                            Address,
+                            1,
+                            &OriginalValue
+                            );
   //
   // The bit0 is 0 to prevent the enabling of the Rom address decoder
   //
@@ -293,6 +302,14 @@ GetOpRomInfo (
                                   1,
                                   &AllOnes
                                   );
+
+  // Write Back
+  PciRootBridgeIo->Pci.Write(PciRootBridgeIo,
+                            EfiPciWidthUint32,
+                            Address,
+                            1,
+                            &OriginalValue
+                            );
   if (EFI_ERROR (Status)) {
     return EFI_NOT_FOUND;
   }

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciOptionRomSupport.h
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciOptionRomSupport.h
@@ -108,6 +108,20 @@ LoadOpRomImage (
   );
 
 /**
+  Load Option Rom image Light for specified PCI device.
+
+  @param PciDevice Pci device instance.
+
+  @retval EFI_OUT_OF_RESOURCES No enough memory to hold image.
+  @retval EFI_SUCESS           Successfully loaded Option Rom.
+
+**/
+EFI_STATUS
+LoadOpRomImageLight (
+  IN PCI_IO_DEVICE   *PciDevice
+  );
+
+/**
   Enable/Disable Option Rom decode.
 
   @param PciDevice    Pci device instance.


### PR DESCRIPTION
OVMF provides one mechanism to pass the specific EFI image by using PCI
ROM Bar. When the PCI rom bar is found, it can load the EFI image from
the rom bar and initialize the PCI device. This can avoid that the specific
EFI image needs to be built into the OVMF image.
   The OVMF on ACRN uses the light mechanism to scan pci devices. In such
case the PCI rom will be skipped and it can't use the PCI rombar to load
the EFI image.
   This patch set tries to check the PCI rom in course of light scan and when
the ROM bar exists, it can try to load the EFI image