### PR TITLE
UefiCpuPkg Vtf0: Clear CR4.MCE in default CR4

### DIFF
--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -552,7 +552,7 @@
   # Point to the MdeModulePkg/Application/UiApp/UiApp.inf
   gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile|{ 0x21, 0xaa, 0x2c, 0x46, 0x14, 0x76, 0x03, 0x45, 0x83, 0x6e, 0x8a, 0xb6, 0xf4, 0x66, 0x23, 0x31 }
 
-  gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVendor|L"ARCN"
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVendor|L"ACRN"
   gEfiMdePkgTokenSpaceGuid.PcdDefaultTerminalType|4
 
   gPcAtChipsetPkgTokenSpaceGuid.PcdIsaAcpiCom2Enable|FALSE

--- a/UefiCpuPkg/ResetVector/Vtf0/Ia16/Real16ToFlat32.asm
+++ b/UefiCpuPkg/ResetVector/Vtf0/Ia16/Real16ToFlat32.asm
@@ -14,12 +14,12 @@
 ;------------------------------------------------------------------------------
 
 %define SEC_DEFAULT_CR0  0x40000023
-%define SEC_DEFAULT_CR4  0x640
+%define SEC_DEFAULT_CR4  0x600
 
 BITS    16
 
 ;
-; Modified:  EAX, EBX
+; Modified:  EAX, EBX, ECX, EDX
 ;
 ; @param[out]     DS       Selector allowing flat access to all addresses
 ; @param[out]     ES       Selector allowing flat access to all addresses
@@ -47,7 +47,14 @@ o32 lgdt    [cs:bx]
 BITS    32
 jumpTo32BitAndLandHere:
 
+    mov     eax, 1
+    cpuid
     mov     eax, SEC_DEFAULT_CR4
+
+    test    edx, (1 << 7)               ; Check for MCE capabilities
+    jz      .mceNotSupported
+    or      eax, (1 << 6)               ; Set CR4.MCE
+.mceNotSupported:
     mov     cr4, eax
 
     debugShowPostCode POSTCODE_32BIT_MODE


### PR DESCRIPTION
ACRN hypervisor doesn't allow setting CR4.MCE when machine check passthrough is disabled. Clear that bit by default.