### PR TITLE
support virtio1.0 for win11

### DIFF
--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -751,7 +751,7 @@
 !endif
   }
   OvmfPkg/VirtioPciDeviceDxe/VirtioPciDeviceDxe.inf
-  #OvmfPkg/Virtio10Dxe/Virtio10.inf
+  OvmfPkg/Virtio10Dxe/Virtio10.inf
   OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
   OvmfPkg/GvtGopDxe/GvtGopDxe.inf
   #OvmfPkg/VirtioScsiDxe/VirtioScsi.inf

--- a/OvmfPkg/OvmfPkgX64.fdf
+++ b/OvmfPkg/OvmfPkgX64.fdf
@@ -227,7 +227,7 @@ INF  MdeModulePkg/Universal/Metronome/Metronome.inf
 INF  OvmfPkg/AcrnRealTimeClockRuntimeDxe/AcrnRealTimeClockRuntimeDxe.inf
 
 INF  OvmfPkg/VirtioPciDeviceDxe/VirtioPciDeviceDxe.inf
-#INF  OvmfPkg/Virtio10Dxe/Virtio10.inf
+INF  OvmfPkg/Virtio10Dxe/Virtio10.inf
 INF  OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
 INF  OvmfPkg/GvtGopDxe/GvtGopDxe.inf
 #INF  OvmfPkg/VirtioScsiDxe/VirtioScsi.inf


### PR DESCRIPTION
win11 can only boot with virtio blk dev on virtio1.0 without legacy mode

Tracked-On: ACRN-13073